### PR TITLE
BUG: fix the relaxivity value

### DIFF
--- a/CLI/PkModeling.xml
+++ b/CLI/PkModeling.xml
@@ -30,11 +30,11 @@
     </float>    
     <float>
       <name>RelaxivityValue</name>   
-      <description><![CDATA[Relaxivity value.]]></description>
+      <description><![CDATA[Contrast agent relaxivity value. Default value corresponds to Gd-DPTA (Magnevist) at 3T.]]></description>
       <longflag>relaxivity</longflag>      
       <label>Relaxivity Value</label>
       <channel>input</channel>
-      <default>0.0049</default>      
+      <default>0.0039</default>      
     </float>
     <float hidden="true">
       <name>S0GradValue</name>   


### PR DESCRIPTION
The updated value is based on the following reference:

Pintaske J, Martirosian P, Graf H, Erb G, Lodemann K-P, Claussen CD, Schick F.
Relaxivity of Gadopentetate Dimeglumine (Magnevist), Gadobutrol (Gadovist), and
Gadobenate Dimeglumine (MultiHance) in human blood plasma at 0.2, 1.5, and 3
Tesla. Investigative radiology. 2006 March;41(3):213–21.
