### PR TITLE
COMP: fix compile error on Windows

### DIFF
--- a/CLI/itkConcentrationToQuantitativeImageFilter.hxx
+++ b/CLI/itkConcentrationToQuantitativeImageFilter.hxx
@@ -8,6 +8,9 @@
 #include "itkLevenbergMarquardtOptimizer.h"
 #include "vnl/vnl_math.h"
 
+// work around compile error on Windows
+#define M_PI 3.1415926535897932384626433832795
+
 #include "itkConcentrationToQuantitativeImageFilter.h"
 
 

--- a/PkSolver/PkSolver.cxx
+++ b/PkSolver/PkSolver.cxx
@@ -17,8 +17,8 @@
 #include <itkImageRegionIterator.h>
 #include <itkLevenbergMarquardtOptimizer.h>
 #include "PkSolver.h"
-#include <math.h>
 #include "itkTimeProbesCollectorBase.h"
+
 
 namespace itk
 {	

--- a/PkSolver/PkSolver.h
+++ b/PkSolver/PkSolver.h
@@ -20,6 +20,9 @@
 #include <vnl/algo/vnl_convolve.h>
 #include "itkArray.h"
 
+// work around compile error on Win
+#define M_PI 3.1415926535897932384626433832795
+
 namespace itk
 {
 


### PR DESCRIPTION
http://slicer.cdash.org/viewBuildError.php?buildid=243493

Error: "error C2065: 'M_PI' : undeclared identifier"
Also see http://winwiki.org/error-c2065-m_pi-undeclared-identifier/

M_PI is now defined explicitly.
