### PR TITLE
COMP: Remove unsed itkv3 header files

### DIFF
--- a/CLI/itkConcentrationToQuantitativeImageFilter.h
+++ b/CLI/itkConcentrationToQuantitativeImageFilter.h
@@ -13,7 +13,6 @@
 #include "itkArray.h"
 #include "itkArray2D.h"
 #include "itkVectorImage.h"
-#include "itkImageToVectorImageFilter.h"
 #include "itkImageRegionIterator.h"
 #include "itkCastImageFilter.h"
 #include "PkSolver.h"

--- a/CLI/itkSignalIntensityToConcentrationImageFilter.h
+++ b/CLI/itkSignalIntensityToConcentrationImageFilter.h
@@ -13,7 +13,6 @@
 #include "itkImageToImageFilter.h"
 #include "itkImage.h"
 #include "itkVectorImage.h"
-#include "itkImageToVectorImageFilter.h"
 #include "itkExtractImageFilter.h"
 #include "itkImageRegionIterator.h"
 #include "itkSignalIntensityToS0ImageFilter.h"

--- a/CLI/itkSignalIntensityToS0ImageFilter.h
+++ b/CLI/itkSignalIntensityToS0ImageFilter.h
@@ -11,7 +11,6 @@
 #include "itkImageToImageFilter.h"
 #include "itkImage.h"
 #include "itkVectorImage.h"
-#include "itkImageToVectorImageFilter.h"
 #include "itkImageRegionIterator.h"
 #include "PkSolver.h"
 


### PR DESCRIPTION
The class itkImageToVectorImageFilter is only available when
ITKv3 compatibility is on. The upcoming Slicer release will turn the
ITKv3 compatibility off.

The class was never used.