### PR TITLE
ENH: add output of the optimizer diagnostics code

### DIFF
--- a/CLI/PkModeling.cxx
+++ b/CLI/PkModeling.cxx
@@ -4,7 +4,7 @@
   Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/PkModeling/PkModeling.cxx $
   Language:  C++
   Date:      $Date: 2012-06-06 $
-  
+
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
@@ -105,7 +105,7 @@ std::vector<float> GetTiming(itk::MetaDataDictionary& dictionary)
     {
     itkGenericExceptionMacro("Missing attribute 'MultiVolume.FrameIdentifyingDICOMTagName'.");
     }
-  
+
   return triggerTimes;
 }
 
@@ -113,7 +113,7 @@ std::vector<float> GetTiming(itk::MetaDataDictionary& dictionary)
 // Read an AIF from a CSV style file.  Columns are timing and concentration.
 //
 //
-bool GetPrescribedAIF(const std::string& fileName, 
+bool GetPrescribedAIF(const std::string& fileName,
                       std::vector<float>& timing, std::vector<float>& aif)
 {
   timing.clear();
@@ -131,12 +131,12 @@ bool GetPrescribedAIF(const std::string& fileName,
   while (!csv.eof())
     {
     getline(csv, line);
-      
+
     if (line[0] == '#')
       {
       continue;
       }
-      
+
     std::vector<std::string> svalues;
     splitString(line, ",", svalues);  /// from PkModelingCLP.h
 
@@ -213,9 +213,9 @@ int DoIt( int argc, char * argv[], const T1 &, const T2 &)
 
   typedef itk::ResampleImageFilter<MaskVolumeType,MaskVolumeType> ResamplerType;
   typedef itk::NearestNeighborInterpolateImageFunction<MaskVolumeType> InterpolatorType;
-  
+
   //Read VectorVolume
-  typename VectorVolumeReaderType::Pointer multiVolumeReader 
+  typename VectorVolumeReaderType::Pointer multiVolumeReader
     = VectorVolumeReaderType::New();
   multiVolumeReader->SetFileName(InputFourDImageFileName.c_str() );
   multiVolumeReader->Update();
@@ -239,51 +239,51 @@ int DoIt( int argc, char * argv[], const T1 &, const T2 &)
     }
   catch (itk::ExceptionObject &exc)
     {
-    itkGenericExceptionMacro(<< exc.GetDescription() 
-            << " Image " << InputFourDImageFileName.c_str() 
+    itkGenericExceptionMacro(<< exc.GetDescription()
+            << " Image " << InputFourDImageFileName.c_str()
             << " does not contain sufficient attributes to support algorithms.");
     return EXIT_FAILURE;
     }
 
   // // EchoTime
   // float echoTime = 0.0;
-  // try 
+  // try
   //   {
   //   echoTime = GetEchoTime(inputVectorVolume->GetMetaDataDictionary());
   //   }
   // catch (itk::ExceptionObject &exc)
   //   {
-  //   itkGenericExceptionMacro(<< exc.GetDescription() 
-  //           << " Image " << InputFourDImageFileName.c_str() 
+  //   itkGenericExceptionMacro(<< exc.GetDescription()
+  //           << " Image " << InputFourDImageFileName.c_str()
   //           << " does not contain sufficient attributes to support algorithms.");
   //   return EXIT_FAILURE;
-    
+
   //   }
 
   // FlipAngle
   float FAValue = 0.0;
-  try 
+  try
     {
     FAValue = GetFlipAngle(inputVectorVolume->GetMetaDataDictionary());
     }
   catch (itk::ExceptionObject &exc)
     {
-    itkGenericExceptionMacro(<< exc.GetDescription() 
-            << " Image " << InputFourDImageFileName.c_str() 
+    itkGenericExceptionMacro(<< exc.GetDescription()
+            << " Image " << InputFourDImageFileName.c_str()
             << " does not contain sufficient attributes to support algorithms.");
     return EXIT_FAILURE;
     }
 
   // RepetitionTime
   float TRValue = 0.0;
-  try 
+  try
     {
     TRValue = GetRepetitionTime(inputVectorVolume->GetMetaDataDictionary());
     }
   catch (itk::ExceptionObject &exc)
     {
-    itkGenericExceptionMacro(<< exc.GetDescription() 
-            << " Image " << InputFourDImageFileName.c_str() 
+    itkGenericExceptionMacro(<< exc.GetDescription()
+            << " Image " << InputFourDImageFileName.c_str()
             << " does not contain sufficient attributes to support algorithms.");
     return EXIT_FAILURE;
     }
@@ -340,7 +340,7 @@ int DoIt( int argc, char * argv[], const T1 &, const T2 &)
     {
     usingPrescribedAIF = GetPrescribedAIF(PrescribedAIFFileName, prescribedAIFTiming, prescribedAIF);
     }
- 
+
   if (AIFMaskFileName == "" && !usingPrescribedAIF && !UsePopulationAIF)
     {
     std::cerr << "Either a mask localizing the region over which to ";
@@ -383,7 +383,7 @@ int DoIt( int argc, char * argv[], const T1 &, const T2 &)
 
   if(OutputConcentrationsImageFileName != "")
     {
-    // need to initialize the attributes, otherwise Slicer treats 
+    // need to initialize the attributes, otherwise Slicer treats
     //  this as a Vector volume, not MultiVolume
     FloatVectorVolumeType::Pointer concentrationsVolume = converter->GetOutput();
     concentrationsVolume->SetMetaDataDictionary(inputVectorVolume->GetMetaDataDictionary());
@@ -410,7 +410,7 @@ int DoIt( int argc, char * argv[], const T1 &, const T2 &)
     quantifier->UsePopulationAIFOn();
     quantifier->SetAIFMask(aifMaskVolume );
     }
-  else 
+  else
     {
     quantifier->SetAIFMask(aifMaskVolume );
     }
@@ -503,7 +503,7 @@ int DoIt( int argc, char * argv[], const T1 &, const T2 &)
 
   if (!OutputFittedDataImageFileName.empty())
     {
-    // need to initialize the attributes, otherwise Slicer treats 
+    // need to initialize the attributes, otherwise Slicer treats
     //  this as a Vector volume, not MultiVolume
     FloatVectorVolumeType::Pointer fittedVolume = quantifier->GetFittedDataOutput();
     fittedVolume->SetMetaDataDictionary(inputVectorVolume->GetMetaDataDictionary());
@@ -526,8 +526,18 @@ int DoIt( int argc, char * argv[], const T1 &, const T2 &)
     batwriter->Update();
     }
 
+  if (!OutputOptimizerDiagnosticsImageFileName.empty())
+    {
+    typename OutputVolumeWriterType::Pointer diagwriter
+      = OutputVolumeWriterType::New();
+    diagwriter->SetInput(quantifier->GetOptimizerDiagnosticsOutput() );
+    diagwriter->SetFileName(OutputOptimizerDiagnosticsImageFileName.c_str());
+    diagwriter->SetUseCompression(1);
+    diagwriter->Update();
+  }
+
   return EXIT_SUCCESS;
-}  
+}
 
 }
 
@@ -588,4 +598,3 @@ int main( int argc, char * argv[] )
     }
   return EXIT_SUCCESS;
 }
-

--- a/CLI/PkModeling.xml
+++ b/CLI/PkModeling.xml
@@ -13,92 +13,92 @@
     <label>PkModeling Parameters</label>
     <description><![CDATA[Parameters used for PkModeling]]></description>
     <float>
-      <name>T1PreBloodValue</name>   
+      <name>T1PreBloodValue</name>
       <description><![CDATA[T1 value for blood.]]></description>
-      <longflag>T1Blood</longflag>      
+      <longflag>T1Blood</longflag>
       <label>T1 Blood Value</label>
       <channel>input</channel>
       <default>1600</default>
-    </float>    
+    </float>
     <float>
-      <name>T1PreTissueValue</name>   
+      <name>T1PreTissueValue</name>
       <description><![CDATA[T1 value for tissue.]]></description>
-      <longflag>T1Tissue</longflag>      
+      <longflag>T1Tissue</longflag>
       <label>T1 Tissue Value</label>
       <channel>input</channel>
       <default>1597</default>
-    </float>    
+    </float>
     <float>
-      <name>RelaxivityValue</name>   
+      <name>RelaxivityValue</name>
       <description><![CDATA[Contrast agent relaxivity value. Default value corresponds to Gd-DPTA (Magnevist) at 3T.]]></description>
-      <longflag>relaxivity</longflag>      
+      <longflag>relaxivity</longflag>
       <label>Relaxivity Value</label>
       <channel>input</channel>
       <default>0.0039</default>
     </float>
     <float hidden="true">
-      <name>S0GradValue</name>   
+      <name>S0GradValue</name>
       <description><![CDATA[Signal Gradient Threshold value.]]></description>
-      <longflag>S0grad</longflag>      
+      <longflag>S0grad</longflag>
       <label>Signal Gradient Threshold Value</label>
       <channel>input</channel>
-      <default>15.0</default>      
-    </float>	
+      <default>15.0</default>
+    </float>
     <float hidden="true">
-      <name>FTolerance</name>   
+      <name>FTolerance</name>
       <description><![CDATA[Tolerance on function value for establishing convergence.]]></description>
-      <longflag>fTolerance</longflag>      
+      <longflag>fTolerance</longflag>
       <label>F Tolerance Value</label>
       <channel>input</channel>
-      <default>1e-4</default>      
+      <default>1e-4</default>
     </float>
     <float hidden="true">
-      <name>GTolerance</name>   
+      <name>GTolerance</name>
       <description><![CDATA[Tolerance on gradient value for establishing convergence.]]></description>
-      <longflag>gTolerance</longflag>      
+      <longflag>gTolerance</longflag>
       <label>G Tolerance Value</label>
       <channel>input</channel>
-      <default>1e-4</default>      
+      <default>1e-4</default>
     </float>
     <float hidden="true">
-      <name>XTolerance</name>   
+      <name>XTolerance</name>
       <description><![CDATA[Tolerance on parameter values for establishing convergence.]]></description>
-      <longflag>xTolerance</longflag>      
+      <longflag>xTolerance</longflag>
       <label>X Tolerance Value</label>
       <channel>input</channel>
       <default>1e-5</default>
     </float>
     <float hidden="true">
-      <name>Epsilon</name>   
+      <name>Epsilon</name>
       <description><![CDATA[Epsilon value.]]></description>
-      <longflag>epsilon</longflag>      
+      <longflag>epsilon</longflag>
       <label>Epsilon Value</label>
       <channel>input</channel>
-      <default>1e-9</default>      
+      <default>1e-9</default>
     </float>
     <float hidden="true">
-      <name>MaxIter</name>   
+      <name>MaxIter</name>
       <description><![CDATA[Maximum number of iterations in optimizing the parameter estimation at each voxel.]]></description>
-      <longflag>maxIter</longflag>      
+      <longflag>maxIter</longflag>
       <label>Maximum number of iterations</label>
       <channel>input</channel>
-      <default>200</default>      
+      <default>200</default>
     </float>
     <float>
-      <name>Hematocrit</name>   
+      <name>Hematocrit</name>
       <description><![CDATA[Hematocrit value, volume percentage of red blood cells in blood.]]></description>
-      <longflag>hematocrit</longflag>      
+      <longflag>hematocrit</longflag>
       <label>Hematocrit Value</label>
       <channel>input</channel>
       <default>0.4</default>
     </float>
     <float>
-      <name>AUCTimeInterval</name>   
+      <name>AUCTimeInterval</name>
       <description><![CDATA[AUC Time Interval value.]]></description>
-      <longflag>aucTimeInterval</longflag>      
+      <longflag>aucTimeInterval</longflag>
       <label>AUC Time Interval Value</label>
       <channel>input</channel>
-      <default>90</default>      
+      <default>90</default>
     </float>
     <boolean>
       <name>ComputeFpv</name>
@@ -117,14 +117,14 @@
   </parameters>
   <parameters>
     <label>IO</label>
-    <description><![CDATA[Input/output parameters]]></description>    
+    <description><![CDATA[Input/output parameters]]></description>
     <image type="dynamic-contrast-enhanced">
       <name>InputFourDImageFileName</name>
       <label>Input 4D Image</label>
       <channel>input</channel>
       <index>0</index>
       <description><![CDATA[Input 4D Image (txyz)]]></description>
-    </image>	 
+    </image>
 
     <image type="label">
       <name>ROIMaskFileName</name>
@@ -160,41 +160,41 @@
       <name>OutputKtransFileName</name>
       <longflag>outputKtrans</longflag>
       <label>Output Ktrans image</label>
-      <channel>output</channel>      
+      <channel>output</channel>
       <description><![CDATA[Output volume transfer constant between blood plasma and EES (extracellular-extravascular space) at each voxel.]]></description>
     </image>
     <image>
       <name>OutputVeFileName</name>
       <longflag>outputVe</longflag>
       <label>Output ve image</label>
-      <channel>output</channel>      
+      <channel>output</channel>
       <description><![CDATA[Output fractional volume for extracellular space at each voxel.]]></description>
     </image>
     <image>
       <name>OutputFpvFileName</name>
       <longflag>outputFpv</longflag>
       <label>Output fpv image</label>
-      <channel>output</channel>      
+      <channel>output</channel>
       <description><![CDATA[Output fractional plasma volume at each voxel.]]></description>
     </image>
     <image>
       <name>OutputMaxSlopeFileName</name>
       <longflag>outputMaxSlope</longflag>
       <label>Output maximum slope image</label>
-      <channel>output</channel>      
+      <channel>output</channel>
       <description><![CDATA[Output maximum slope in the time series curve of each voxel.]]></description>
     </image>
     <image>
       <name>OutputAUCFileName</name>
       <longflag>outputAUC</longflag>
       <label>Output AUC image</label>
-      <channel>output</channel>      
+      <channel>output</channel>
       <description><![CDATA[Output area under the curve (AUC) of each voxel, measured from bolus arrival time to the end time of interval, normalized by the AUC of the AIF.]]></description>
     </image>
   </parameters>
   <parameters advanced="true">
     <label>Advanced options</label>
-    <description><![CDATA[Debugging and advanced research options.]]></description> 
+    <description><![CDATA[Debugging and advanced research options.]]></description>
     <string-enumeration>
       <name>BATCalculationMode</name>
       <longflag>BATCalculationMode</longflag>
@@ -216,7 +216,7 @@
       <name>OutputRSquaredFileName</name>
       <longflag>outputRSquared</longflag>
       <label>Output R-squared goodness of fit image</label>
-      <channel>output</channel>      
+      <channel>output</channel>
       <description><![CDATA[R-squared goodness of fit of the model to each voxel. Setting this output changes the returned images.  When this output is not used, the output parameter volumes only contain the voxels where good fits were obtained.  When this output is set, the parameter volumes for every voxel is output and may be masked by the R-squared volume in a separate module.]]></description>
     </image>
     <image>
@@ -232,13 +232,20 @@
       <channel>output</channel>
       <longflag>concentrations</longflag>
       <description><![CDATA[Output Concentrations 4D Image (txyz)]]></description>
-    </image>	 
+    </image>
     <image type="dynamic-contrast-enhanced">
       <name>OutputFittedDataImageFileName</name>
       <label>Output Fitted Data 4D Image</label>
       <channel>output</channel>
       <longflag>fitted</longflag>
       <description><![CDATA[Output Fitted Data 4D Image (txyz)]]></description>
-    </image>	 
+    </image>
+    <image>
+      <name>OutputOptimizerDiagnosticsImageFileName</name>
+      <label>Output Diagnostics Image</label>
+      <channel>output</channel>
+      <longflag>outputDiagnostics</longflag>
+      <description><![CDATA[Output map with the optimizer diagnostics. Code meanings are as follows:\n0: OIOIOI -- failure in leastsquares function\n1: OIOIOI -- lmdif dodgy input\n2: converged to ftol\n3: converged to xtol\n4: converged nicely\n5: converged via gtol\n6: too many iterations\n7: ftol is too small. no further reduction in the sum of squares is possible.\n8: xtol is too small. no further improvement in the approximate solution x is possible.\n9: gtol is too small. Fx is orthogonal to the columns of the jacobian to machine precision.\n10: OIOIOI: unkown info code from lmder.\n]]></description>
+    </image>
   </parameters>
 </executable>

--- a/CLI/itkConcentrationToQuantitativeImageFilter.h
+++ b/CLI/itkConcentrationToQuantitativeImageFilter.h
@@ -198,6 +198,8 @@ public:
 
   VectorVolumeType* GetFittedDataOutput();
 
+  TOutputImage* GetOptimizerDiagnosticsOutput();
+
 protected:
   ConcentrationToQuantitativeImageFilter();
   ~ConcentrationToQuantitativeImageFilter(){

--- a/PkSolver/PkSolver.cxx
+++ b/PkSolver/PkSolver.cxx
@@ -21,10 +21,10 @@
 #include <string>
 
 namespace itk
-{	
+{
 //
 // Support routines/classes used internally in the PkSolver
-// 
+//
 static itk::TimeProbesCollectorBase probe;
 
 int m_ConstantBAT;
@@ -32,12 +32,12 @@ std::string m_BATCalculationMode;
 
 //
 // Implementation of the PkSolver API
-// 
+//
 //
 
-bool pk_solver (int signalSize, const float* timeAxis, 
-                const float* PixelConcentrationCurve, 
-                const float* BloodConcentrationCurve, 
+bool pk_solver (int signalSize, const float* timeAxis,
+                const float* PixelConcentrationCurve,
+                const float* BloodConcentrationCurve,
                 float& Ktrans, float& Ve, float& Fpv,
                 float fTol, float gTol, float xTol,
                 float epsilon, int maxIter,
@@ -48,15 +48,15 @@ bool pk_solver (int signalSize, const float* timeAxis,
 {
   // Note the unit: timeAxis should be in minutes!! This could be related to the following parameters!!
   // fTol      =  1e-4;  // Function value tolerance
-  // gTol      =  1e-4;  // Gradient magnitude tolerance 
+  // gTol      =  1e-4;  // Gradient magnitude tolerance
   // xTol      =  1e-5;  // Search space tolerance
   // epsilon   =  1e-9;    // Step
   // maxIter   =   200;  // Maximum number of iterations
 
   m_BATCalculationMode = BATCalculationMode;
   m_ConstantBAT = constantBAT;
-  
-  // Levenberg Marquardt optimizer  
+
+  // Levenberg Marquardt optimizer
   itk::LevenbergMarquardtOptimizer::Pointer  optimizer = itk::LevenbergMarquardtOptimizer::New();
   LMCostFunction::Pointer costFunction = LMCostFunction::New();
 
@@ -72,7 +72,7 @@ bool pk_solver (int signalSize, const float* timeAxis,
     }
   initialValue[0] = 0.1;     //Ktrans //...
   initialValue[1] = 0.5;     //ve //...
- 
+
   costFunction->SetNumberOfValues (signalSize);
 
   costFunction->SetCb (BloodConcentrationCurve, signalSize); //BloodConcentrationCurve
@@ -100,15 +100,15 @@ bool pk_solver (int signalSize, const float* timeAxis,
 
   vnlOptimizer->set_f_tolerance( fTol );
   vnlOptimizer->set_g_tolerance( gTol );
-  vnlOptimizer->set_x_tolerance( xTol ); 
+  vnlOptimizer->set_x_tolerance( xTol );
   vnlOptimizer->set_epsilon_function( epsilon );
   vnlOptimizer->set_max_function_evals( maxIter );
 
-  // We start not so far from the solution 
+  // We start not so far from the solution
 
   optimizer->SetInitialPosition( initialValue );
 
-  CommandIterationUpdateLevenbergMarquardt::Pointer observer = 
+  CommandIterationUpdateLevenbergMarquardt::Pointer observer =
     CommandIterationUpdateLevenbergMarquardt::New();
   optimizer->AddObserver( itk::IterationEvent(), observer );
   optimizer->AddObserver( itk::FunctionEvaluationIterationEvent(), observer );
@@ -127,20 +127,22 @@ bool pk_solver (int signalSize, const float* timeAxis,
   itk::LevenbergMarquardtOptimizer::ParametersType finalPosition;
   finalPosition = optimizer->GetCurrentPosition();
 
-  //Solution: remove the scale of 100  
+  //Solution: remove the scale of 100
   Ktrans = finalPosition[0];
   Ve = finalPosition[1];
   if(modelType == itk::LMCostFunction::TOFTS_3_PARAMETER)
     {
-    Fpv = finalPosition[2];  
+    Fpv = finalPosition[2];
     }
+
+  std::cout << optimizer->GetStopConditionDescription() << std::endl;
 
   return true;
 }
 
-bool pk_solver(int signalSize, const float* timeAxis, 
-               const float* PixelConcentrationCurve, 
-               const float* BloodConcentrationCurve, 
+unsigned pk_solver(int signalSize, const float* timeAxis,
+               const float* PixelConcentrationCurve,
+               const float* BloodConcentrationCurve,
                float& Ktrans, float& Ve, float& Fpv,
                float fTol, float gTol, float xTol,
                float epsilon, int maxIter,
@@ -156,7 +158,7 @@ bool pk_solver(int signalSize, const float* timeAxis,
   // probe.Start("pk_solver");
   // Note the unit: timeAxis should be in minutes!! This could be related to the following parameters!!
   // fTol      =  1e-4;  // Function value tolerance
-  // gTol      =  1e-4;  // Gradient magnitude tolerance 
+  // gTol      =  1e-4;  // Gradient magnitude tolerance
   // xTol      =  1e-5;  // Search space tolerance
   // epsilon   =  1e-9;    // Step
   // maxIter   =   200;  // Maximum number of iterations
@@ -165,8 +167,8 @@ bool pk_solver(int signalSize, const float* timeAxis,
   m_BATCalculationMode = BATCalculationMode;
   m_ConstantBAT = constantBAT;
 
-  // Levenberg Marquardt optimizer  
-        
+  // Levenberg Marquardt optimizer
+
   //////////////
   LMCostFunction::ParametersType initialValue;
   if(modelType == itk::LMCostFunction::TOFTS_2_PARAMETER)
@@ -180,9 +182,9 @@ bool pk_solver(int signalSize, const float* timeAxis,
     }
   initialValue[0] = 0.1;     //Ktrans //...
   initialValue[1] = 0.5;     //ve //...
-        
+
   costFunction->SetNumberOfValues (signalSize);
-  
+
 
   costFunction->SetCb (BloodConcentrationCurve, signalSize); //BloodConcentrationCurve
   costFunction->SetCv (PixelConcentrationCurve, signalSize); //Signal Y
@@ -191,18 +193,18 @@ bool pk_solver(int signalSize, const float* timeAxis,
   costFunction->GetValue (initialValue); //...
   costFunction->SetModelType(modelType);
 
-  optimizer->UseCostFunctionGradientOff();   
+  optimizer->UseCostFunctionGradientOff();
 
   try {
-     optimizer->SetCostFunction( costFunction ); 
+     optimizer->SetCostFunction( costFunction );
   }
   catch ( itk::ExceptionObject & e ) {
   std::cout << "Exception thrown ! " << std::endl;
   std::cout << "An error ocurred during Optimization" << std::endl;
   std::cout << e << std::endl;
   return false;
-  }   
-        
+  }
+
   itk::LevenbergMarquardtOptimizer::InternalOptimizerType * vnlOptimizer = optimizer->GetOptimizer();//...
 
   vnlOptimizer->set_f_tolerance( fTol ); //...
@@ -210,11 +212,11 @@ bool pk_solver(int signalSize, const float* timeAxis,
   vnlOptimizer->set_x_tolerance( xTol ); //...
   vnlOptimizer->set_epsilon_function( epsilon ); //...
   vnlOptimizer->set_max_function_evals( maxIter ); //...
-        
-  // We start not so far from the solution 
-        
-  optimizer->SetInitialPosition( initialValue ); //...       
-  
+
+  // We start not so far from the solution
+
+  optimizer->SetInitialPosition( initialValue ); //...
+
   try {
   //  probe.Start("optimizer");
   optimizer->StartOptimization();
@@ -233,25 +235,45 @@ bool pk_solver(int signalSize, const float* timeAxis,
   finalPosition = optimizer->GetCurrentPosition();
   //std::cerr << finalPosition[0] << ", " << finalPosition[1] << ", " << finalPosition[2] << std::endl;
 
-        
-  //Solution: remove the scale of 100  
+
+  //Solution: remove the scale of 100
   Ktrans = finalPosition[0];
   Ve = finalPosition[1];
   if(modelType == itk::LMCostFunction::TOFTS_3_PARAMETER)
     {
-    Fpv = finalPosition[2];  
+    Fpv = finalPosition[2];
     }
+
+
+  std::string diagnosticsCode = optimizer->GetStopConditionDescription();
+  unsigned errorCode;
+  for(errorCode=0;errorCode<NumOptimizerDiagnosticCodes;errorCode++){
+    if(diagnosticsCode.find(OptimizerDiagnosticStrings[errorCode]) != std::string::npos)
+      break;
+  }
 
   // "Project" back onto the feasible set.  Should really be done as a
   // constraint in the optimization.
-  if(Ve<0) Ve = 0;
-  if(Ve>1) Ve = 1;
-  if(Ktrans<0) Ktrans = 0;
-  if(Ktrans>5) Ktrans = 5;
-		
+  if(Ve<0){
+    Ve = 0;
+    errorCode |= VE_CLAMPED;
+  }
+  if(Ve>1){
+    Ve = 1;
+    errorCode |= VE_CLAMPED;
+  }
+  if(Ktrans<0){
+    Ktrans = 0;
+    errorCode |= KTRANS_CLAMPED;
+  }
+  if(Ktrans>5){
+    Ktrans = 5;
+    errorCode |= KTRANS_CLAMPED;
+  }
+
   //if((Fpv>1)||(Fpv<0)) Fpv = 0;
   //  probe.Stop("pk_solver");
-  return true;
+  return errorCode;
 }
 
 void pk_report()
@@ -267,8 +289,8 @@ void pk_clear()
 #define PI 3.1415926535897932384626433832795
 #define IS_NAN(x) ((x) != (x))
 
-bool convert_signal_to_concentration (unsigned int signalSize, 
-                                      const float* SignalIntensityCurve, 
+bool convert_signal_to_concentration (unsigned int signalSize,
+                                      const float* SignalIntensityCurve,
                                       const float T1Pre, float TR, float FA,
                                       float* concentration,
                                       float RGd_relaxivity,
@@ -276,13 +298,13 @@ bool convert_signal_to_concentration (unsigned int signalSize,
                                       float S0GradThresh)
 {
   const double exp_TR_BloodT1 = exp (-TR/T1Pre);
-  const float alpha = FA * PI/180;  
+  const float alpha = FA * PI/180;
   const double cos_alpha = cos(alpha);
   const double constB = (1-exp_TR_BloodT1) / (1-cos_alpha*exp_TR_BloodT1);
-  
+
   if (s0 == -1.0f)
     s0 = compute_s0_individual_curve (signalSize, SignalIntensityCurve, S0GradThresh, m_BATCalculationMode, m_ConstantBAT);
-            
+
   for (unsigned int t=0; t<signalSize; ++t) {
     const float tSignal = SignalIntensityCurve[t];
     if (tSignal == 0) {
@@ -300,11 +322,11 @@ bool convert_signal_to_concentration (unsigned int signalSize,
       const float ROft = (-1/TR) * log_value;
       if (T1Pre != 0) {
         double Cb = (ROft - (1/T1Pre)) / RGd_relaxivity;
-        assert (IS_NAN (Cb) == false); 
+        assert (IS_NAN (Cb) == false);
         if (Cb < 0)
           Cb = 0;
         concentration[t] = float (Cb);
-      }  
+      }
       else
         concentration[t] = 0;
     }
@@ -313,31 +335,31 @@ bool convert_signal_to_concentration (unsigned int signalSize,
   return true;
 }
 
-float area_under_curve(int signalSize, 
+float area_under_curve(int signalSize,
                        const float* timeAxis,
-                       const float* concentration, 
-                       int BATIndex, 
+                       const float* concentration,
+                       int BATIndex,
                        float aucTimeInterval)
-{	
+{
   float auc = 0.0f;
   if(BATIndex>=signalSize) return auc;
-  //std::cerr << std::endl << "BATIndex:"<<BATIndex << std::endl;	
-	
+  //std::cerr << std::endl << "BATIndex:"<<BATIndex << std::endl;
+
   int lastIndex = BATIndex;
-  //std::cerr << std::endl << "timeAxis[0]:"<< timeAxis[0] << std::endl;	
-  float targetTime = timeAxis[BATIndex]+aucTimeInterval; 
-  //std::cerr << std::endl << "targetTime:"<< targetTime << std::endl;	
+  //std::cerr << std::endl << "timeAxis[0]:"<< timeAxis[0] << std::endl;
+  float targetTime = timeAxis[BATIndex]+aucTimeInterval;
+  //std::cerr << std::endl << "targetTime:"<< targetTime << std::endl;
   float tempTime = timeAxis[BATIndex+1];
-  //std::cerr << std::endl << "tempTime:"<< tempTime << std::endl;	
+  //std::cerr << std::endl << "tempTime:"<< tempTime << std::endl;
 
   //find the last index
   while((tempTime<targetTime)&&(lastIndex<(signalSize-2)))
-    {	
-    lastIndex+=1;		
+    {
+    lastIndex+=1;
     tempTime = timeAxis[lastIndex+1] ;
     //std::cerr << std::endl << "tempTime"<<tempTime << std::endl;
-    }	
-		
+    }
+
   if ((lastIndex-BATIndex)==0) return auc = aucTimeInterval*concentration[BATIndex];
 
   //extract time and concentration
@@ -361,14 +383,14 @@ float area_under_curve(int signalSize,
     }
   concentrationValues[lastIndex-BATIndex+1] = targetY; //put the extra value at the end
   timeValues[lastIndex-BATIndex+1] = targetX; //put the extra time value at the end
-	
+
 //	printf("lastIndex is %f\n", (float)lastIndex);
   for(int i=0; i<(lastIndex-BATIndex+1); ++i)
     {
     concentrationValues[i] = concentration[i+BATIndex];
     timeValues[i] = timeAxis[i+BATIndex];
     //printf("lastIndex is %f,%f\n", (float) concentrationValues[i],(float)timeValues[i]);
-    }	
+    }
 
   //get auc
   auc = intergrate(concentrationValues,timeValues,(lastIndex-BATIndex+2));
@@ -403,7 +425,7 @@ void compute_derivative (int signalSize,
 void compute_derivative_forward (int signalSize,
                          const float* SignalY,
                          float* YDeriv)
-{  
+{
   YDeriv[signalSize-1] = (float) (SignalY[signalSize-1] - SignalY[signalSize-2]);
   for(int i=0; i<signalSize-1; i++) {
     YDeriv[i] = (float) (SignalY[i+1] - SignalY[i]);
@@ -414,7 +436,7 @@ void compute_derivative_backward (int signalSize,
                          const float* SignalY,
                          float* YDeriv)
 {
-  YDeriv[0] = (float) (-SignalY[0] + SignalY[1]);  
+  YDeriv[0] = (float) (-SignalY[0] + SignalY[1]);
   for(int i=1; i<signalSize; i++) {
     YDeriv[i] = (float) (SignalY[i] - SignalY[i-1]);
   }
@@ -459,7 +481,7 @@ bool compute_bolus_arrival_time (int signalSize, const float* SignalY,
     delete [] yd;
     return false;
   }
-  
+
   // Step 1: Smoothing done using Savizky-Golay before this call on Signal or Conc. data
 
   // Step 2: Spatial derivative of smoothed data
@@ -499,9 +521,9 @@ bool compute_bolus_arrival_time (int signalSize, const float* SignalY,
   //   if(yd[i] >= thresh || y0[i] >= y0[i-1])
   //     break;
   // }
-  // FirstPeak = i; 
+  // FirstPeak = i;
   // jvm - end of remove
-  //changing the peak as global peak 
+  //changing the peak as global peak
   FirstPeak = CpIndex;
 
   //delete [] t;
@@ -515,7 +537,7 @@ void compute_gradient_old (int signalSize, const float* SignalY, float* SignalGr
   typedef itk::Image<float, 1>   ImageType;
   typedef itk::GradientMagnitudeImageFilter<ImageType, ImageType>  FilterType;
 
-  ImageType::Pointer SignalImg1D = ImageType::New();  
+  ImageType::Pointer SignalImg1D = ImageType::New();
   ImageType::SizeType imgSize;
   imgSize[0] = signalSize;
   SignalImg1D->SetRegions(imgSize);
@@ -533,43 +555,43 @@ void compute_gradient_old (int signalSize, const float* SignalY, float* SignalGr
   gfilter->Update();
 
   ImageType::Pointer GradientImg1D = gfilter->GetOutput();
-  
+
   IteratorType outputIt (GradientImg1D, GradientImg1D->GetLargestPossibleRegion());
   outputIt.GoToBegin();
   for (unsigned int i=0; !outputIt.IsAtEnd(); i++, ++outputIt) {
-    SignalGradient[i] = outputIt.Get();	
+    SignalGradient[i] = outputIt.Get();
   }
 }
 
 void compute_gradient (int signalSize, const float* SignalY, float* SignalGradient)
-{	
+{
   compute_derivative (signalSize, SignalY, SignalGradient);
-  for(int i=0; i<signalSize; i++) 
+  for(int i=0; i<signalSize; i++)
     {
-    SignalGradient[i] = sqrt(SignalGradient[i]*SignalGradient[i]);		
-    } 
+    SignalGradient[i] = sqrt(SignalGradient[i]*SignalGradient[i]);
+    }
 }
 
 void compute_gradient_forward (int signalSize, const float* SignalY, float* SignalGradient)
 {
   compute_derivative_forward (signalSize, SignalY, SignalGradient);
-  for(int i=0; i<signalSize; i++) 
+  for(int i=0; i<signalSize; i++)
     {
-    SignalGradient[i] = sqrt(SignalGradient[i]*SignalGradient[i]);		
-    } 	
+    SignalGradient[i] = sqrt(SignalGradient[i]*SignalGradient[i]);
+    }
 }
 
 void compute_gradient_backward (int signalSize, const float* SignalY, float* SignalGradient)
-{	
+{
   compute_derivative_backward (signalSize, SignalY, SignalGradient);
-  for(int i=0; i<signalSize; i++) 
+  for(int i=0; i<signalSize; i++)
     {
-    SignalGradient[i] = sqrt(SignalGradient[i]*SignalGradient[i]);		
-    } 	
+    SignalGradient[i] = sqrt(SignalGradient[i]*SignalGradient[i]);
+    }
 }
 
 
-float compute_s0_using_sumsignal_properties (int signalSize, const float* SignalY, 
+float compute_s0_using_sumsignal_properties (int signalSize, const float* SignalY,
                                              const short* lowGradIndex, int FirstPeak)
 {
   double S0 = 0;
@@ -596,7 +618,7 @@ float compute_s0_using_sumsignal_properties (int signalSize, const float* Signal
 
 float compute_s0_individual_curve (int signalSize, const float* SignalY, float S0GradThresh,
                                    std::string BATCalculationMode, int constantBAT)
-{  
+{
   double S0 = 0;
   int ArrivalTime, FirstPeak;
   float MaxSlope;
@@ -605,7 +627,7 @@ float compute_s0_individual_curve (int signalSize, const float* SignalY, float S
   if (BATCalculationMode == "UseConstantBAT")
   {
   // Use constant BAT
-    
+
   ArrivalTime = constantBAT;
   result = true;
   }
@@ -618,14 +640,14 @@ float compute_s0_individual_curve (int signalSize, const float* SignalY, float S
     ///printf ("  Compute compute_s0_individual_curve fails! S0 = 0.\n");
     return 0;
   }
-  
+
   float* SignalGradient = new float[signalSize];
   //above: same
-  compute_gradient(signalSize, SignalY, SignalGradient);    
-  
+  compute_gradient(signalSize, SignalY, SignalGradient);
+
   int count = 0;
   double sum = 0;
-  for (int i=0; i<ArrivalTime; i++) { //updated to i<ArrivalTime by Yingxuan Zhu on 5/5/2012, original i<FirstPeak;	  
+  for (int i=0; i<ArrivalTime; i++) { //updated to i<ArrivalTime by Yingxuan Zhu on 5/5/2012, original i<FirstPeak;
     sum += SignalY[i];
     if (SignalGradient[i] < S0GradThresh) {
       S0 += SignalY[i];
@@ -638,7 +660,7 @@ float compute_s0_individual_curve (int signalSize, const float* SignalY, float S
 	if (count)
 		S0 /= count;
 	else
-		S0 = sum / (ArrivalTime); //updated to sum/(ArrivalTime) by Yingxuan Zhu on 5/5/2012, original sum/(FirstPeak-1);	
+		S0 = sum / (ArrivalTime); //updated to sum/(ArrivalTime) by Yingxuan Zhu on 5/5/2012, original sum/(FirstPeak-1);
   }
   else
 	  S0 = SignalY[0]; //ArrivalTime is 0;
@@ -649,4 +671,3 @@ float compute_s0_individual_curve (int signalSize, const float* SignalY, float S
 }
 
 }; // end of namespace
-

--- a/PkSolver/PkSolver.h
+++ b/PkSolver/PkSolver.h
@@ -27,18 +27,18 @@
 // codes defined in ITKv4 vnl_levenberg_marquardt.cxx:386
 enum OptimizerDiagnosticCodes {
   ERROR_FAILURE = 0,
-  ERROR_DODGY_INPUT,
-  CONVERGED_FTOL,
-  CONVERGED_XTOL,
-  CONVERGED_XFTOL,
-  CONVERGED_GTOL,
-  TOO_MANY_ITERATIONS,
-  FAILED_FTOL_TOO_SMALL,
-  FAILED_XTOL_TOO_SMALL,
-  FAILED_GTOL_TOO_SMALL,
-  FAILED_UNKNOWN = 0x0B, // = 11
+  ERROR_DODGY_INPUT = 1,
+  CONVERGED_FTOL = 2,
+  CONVERGED_XTOL = 3,
+  CONVERGED_XFTOL = 4,
+  CONVERGED_GTOL = 5,
+  TOO_MANY_ITERATIONS = 6,
+  FAILED_FTOL_TOO_SMALL = 7,
+  FAILED_XTOL_TOO_SMALL = 8,
+  FAILED_GTOL_TOO_SMALL = 9,
+  FAILED_UNKNOWN = 10,
   // next are the masks that are specific to the PK modeling process
-  FAILED_NOMATCH = 0x0C, // = 12 optimizer failed, but diagnostics string was not recognized
+  FAILED_NOMATCH = 11, // optimizer failed, but diagnostics string was not recognized
   KTRANS_CLAMPED = 0x10, // = 16 Ktrans was clamped to [0..5]
   VE_CLAMPED = 0x20, // = 32 Ve was clamped to [0..1]
   BAT_DETECTION_FAILED = 0x30, // = 48 BAT detection procedure failed


### PR DESCRIPTION
Assigned per pixel, codes are from ITK vnl_levenberg_marquardt.cxx:388

https://github.com/Kitware/ITK/blob/4cbfdd5f8d6254f472f72e659ded7b7ff5cc562d/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_levenberg_marquardt.cxx#L386

The optimizer codes are kept in the lower byte of the map.

The upper byte contains information about clamping of Ktrans/Ve and
failures in BAT detection.