### PR TITLE
COMP: attempt on fixing dashboard linker errors

### DIFF
--- a/CLI/CMakeLists.txt
+++ b/CLI/CMakeLists.txt
@@ -23,6 +23,12 @@ set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES} PkSolver
   )
 
+#
+# ITK
+#
+set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+include(${ITK_USE_FILE})
+
 #-----------------------------------------------------------------------------
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}

--- a/CLI/Testing/Cxx/CMakeLists.txt
+++ b/CLI/Testing/Cxx/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CLP ${MODULE_NAME})
 
 #-----------------------------------------------------------------------------
 add_executable(${CLP}Test ${CLP}Test.cxx)
-target_link_libraries(${CLP}Test ${CLP}Lib)
+target_link_libraries(${CLP}Test ${CLP}Lib ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES)
 set_target_properties(${CLP}Test PROPERTIES LABELS ${CLP})
 
 #-----------------------------------------------------------------------------

--- a/CLI/Testing/Cxx/PkModelingTest.cxx
+++ b/CLI/Testing/Cxx/PkModelingTest.cxx
@@ -1,11 +1,3 @@
-#if defined(_MSC_VER)
-#pragma warning ( disable : 4786 )
-#endif
-
-#ifdef __BORLANDC__
-#define ITK_LEAN_AND_MEAN
-#endif
-
 #include "itkTestMain.h"
 
 // STD includes


### PR DESCRIPTION
Approach: review a CLI module from Slicer repository and revise for addressing
inconsistencies; specifically, there is a mention of factory-related variable in
the cmake (CLI reviewed - CastScalarVolume).