### PR TITLE
ENH: Add ability to choose integration method (Issue43)

### DIFF
--- a/CLI/PkModeling.cxx
+++ b/CLI/PkModeling.cxx
@@ -372,6 +372,7 @@ type Get##name(itk::MetaDataDictionary& dictionary)           \
     converter->SetconstantBAT(ConstantBAT);
     converter->SetRGD_relaxivity(RelaxivityValue);
     converter->SetS0GradThresh(S0GradValue);
+    converter->SetToftsIntegrationMethod(ToftsIntegrationMethod);
 
     if (T1MapFileName != "")
     {
@@ -425,6 +426,7 @@ type Get##name(itk::MetaDataDictionary& dictionary)           \
     quantifier->Sethematocrit(Hematocrit);
     quantifier->SetconstantBAT(ConstantBAT);
     quantifier->SetBATCalculationMode(BATCalculationMode);
+    quantifier->SetToftsIntegrationMethod(ToftsIntegrationMethod);
     if (ROIMaskFileName != "")
     {
       quantifier->SetROIMask(roiMaskVolume);

--- a/CLI/PkModeling.xml
+++ b/CLI/PkModeling.xml
@@ -7,7 +7,7 @@
   <version>0.1.0.$Revision: 19276 $(alpha)</version>
   <documentation-url>http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/PkModeling</documentation-url>
   <license/>
-  <contributor>Yingxuan Zhu (while at GE), Andrey Fedorov (SPL), John Evans (MGH), Jim Miller (GE)</contributor>
+  <contributor>Yingxuan Zhu (while at GE), Andrey Fedorov (SPL), John Evans (MGH), Jim Miller (GE), Andrew Beers (MGH)</contributor>
   <acknowledgements><![CDATA[This work is part of the National Alliance for Medical Image Computing (NA-MIC), funded by the National Institutes of Health through the NIH Roadmap for Medical Research, and by National Cancer Institute as part of the Quantitative Imaging Network initiative (U01CA151261) and QIICR (U24CA180918).]]></acknowledgements>
   <parameters>
     <label>PkModeling Parameters</label>
@@ -212,6 +212,15 @@
       <channel>input</channel>
       <default>1</default>
     </integer>
+    <string-enumeration>
+      <name>ToftsIntegrationMethod</name>
+      <longflag>ToftsIntegrationMethod</longflag>
+      <label>Fitting Integration Method</label>
+      <description>Determine which integration method will be used when calculating Mean Squared Error in the fitting process.</description>
+      <default>Recursive</default>
+      <element>Recursive</element>
+      <element>Convolutional</element>
+    </string-enumeration>
     <image>
       <name>OutputRSquaredFileName</name>
       <longflag>outputRSquared</longflag>

--- a/CLI/itkConcentrationToQuantitativeImageFilter.h
+++ b/CLI/itkConcentrationToQuantitativeImageFilter.h
@@ -135,6 +135,8 @@ namespace itk
     itkSetMacro(constantBAT, int);
     itkGetMacro(BATCalculationMode, std::string);
     itkSetMacro(BATCalculationMode, std::string);
+    itkGetMacro(ToftsIntegrationMethod, std::string);
+    itkSetMacro(ToftsIntegrationMethod, std::string);
 
     void SetTiming(const std::vector<float>& inputTiming);
     const std::vector<float>& GetTiming();
@@ -246,6 +248,7 @@ namespace itk
     int    m_ModelType;
     bool   m_MaskByRSquared;
     int m_constantBAT;
+    std::string m_ToftsIntegrationMethod;
     std::string m_BATCalculationMode;
 
     std::vector<float> m_Timing;

--- a/CLI/itkConcentrationToQuantitativeImageFilter.hxx
+++ b/CLI/itkConcentrationToQuantitativeImageFilter.hxx
@@ -37,6 +37,7 @@ namespace itk
     m_UsePrescribedAIF = false;
     m_MaskByRSquared = true;
     m_ModelType = itk::LMCostFunction::TOFTS_2_PARAMETER;
+    m_ToftsIntegrationMethod = "Recursive";
     m_constantBAT = 0;
     m_BATCalculationMode = "PeakGradient";
     this->Superclass::SetNumberOfRequiredInputs(1);
@@ -438,6 +439,7 @@ namespace itk
           optimizerErrorCode = pk_solver(timeSize, &timeMinute[0],
             const_cast<float *>(shiftedVectorVoxel.GetDataPointer()),
             &m_AIF[0],
+            m_ToftsIntegrationMethod,
             tempKtrans, tempVe, tempFpv,
             m_fTol, m_gTol, m_xTol,
             m_epsilon, m_maxIter, m_hematocrit,
@@ -862,6 +864,7 @@ namespace itk
     ::PrintSelf(std::ostream& os, Indent indent) const
   {
     Superclass::PrintSelf(os, indent);
+    os << indent << "Integration Method: " << m_ToftsIntegrationMethod << std::endl;
     os << indent << "Function tolerance: " << m_fTol << std::endl;
     os << indent << "Gradient tolerance: " << m_gTol << std::endl;
     os << indent << "Parameter tolerance: " << m_xTol << std::endl;

--- a/CLI/itkSignalIntensityToConcentrationImageFilter.h
+++ b/CLI/itkSignalIntensityToConcentrationImageFilter.h
@@ -105,6 +105,8 @@ namespace itk
     itkSetMacro(S0GradThresh, float);
     itkGetMacro(BATCalculationMode, std::string);
     itkSetMacro(BATCalculationMode, std::string);
+    itkGetMacro(ToftsIntegrationMethod, std::string);
+    itkSetMacro(ToftsIntegrationMethod, std::string);
     itkGetMacro(constantBAT, int);
     itkSetMacro(constantBAT, int);
 
@@ -173,6 +175,7 @@ namespace itk
     float m_RGD_relaxivity;
     float m_S0GradThresh;
     std::string m_BATCalculationMode;
+    std::string m_ToftsIntegrationMethod;
     int m_constantBAT;
   };
 

--- a/PkSolver/PkSolver.cxx
+++ b/PkSolver/PkSolver.cxx
@@ -29,6 +29,7 @@ namespace itk
 
   int m_ConstantBAT;
   std::string m_BATCalculationMode;
+  std::string m_ToftsIntegrationMethod;
 
   //
   // Implementation of the PkSolver API
@@ -38,6 +39,7 @@ namespace itk
   bool pk_solver(int signalSize, const float* timeAxis,
     const float* PixelConcentrationCurve,
     const float* BloodConcentrationCurve,
+    const std::string ToftsIntegrationMethod,
     float& Ktrans, float& Ve, float& Fpv,
     float fTol, float gTol, float xTol,
     float epsilon, int maxIter,
@@ -55,6 +57,7 @@ namespace itk
 
     m_BATCalculationMode = BATCalculationMode;
     m_ConstantBAT = constantBAT;
+    m_ToftsIntegrationMethod = ToftsIntegrationMethod;
 
     // Levenberg Marquardt optimizer
     itk::LevenbergMarquardtOptimizer::Pointer  optimizer = itk::LevenbergMarquardtOptimizer::New();
@@ -79,6 +82,7 @@ namespace itk
     costFunction->SetCv(PixelConcentrationCurve, signalSize); //Signal Y
     costFunction->SetTime(timeAxis, signalSize); //Signal X
     costFunction->SetHematocrit(hematocrit);
+    costFunction->SetIntegrationType(m_ToftsIntegrationMethod);
     costFunction->GetValue(initialValue);
     costFunction->SetModelType(modelType);
 
@@ -147,6 +151,7 @@ namespace itk
   unsigned pk_solver(int signalSize, const float* timeAxis,
     const float* PixelConcentrationCurve,
     const float* BloodConcentrationCurve,
+    const std::string ToftsIntegrationMethod,
     float& Ktrans, float& Ve, float& Fpv,
     float fTol, float gTol, float xTol,
     float epsilon, int maxIter,
@@ -170,6 +175,7 @@ namespace itk
 
     m_BATCalculationMode = BATCalculationMode;
     m_ConstantBAT = constantBAT;
+    m_ToftsIntegrationMethod = ToftsIntegrationMethod;
 
     // Levenberg Marquardt optimizer
 
@@ -194,6 +200,7 @@ namespace itk
     costFunction->SetCv(PixelConcentrationCurve, signalSize); //Signal Y
     costFunction->SetTime(timeAxis, signalSize); //Signal X
     costFunction->SetHematocrit(hematocrit);
+    costFunction->SetIntegrationType(m_ToftsIntegrationMethod);
     costFunction->GetValue(initialValue); //...
     costFunction->SetModelType(modelType);
 


### PR DESCRIPTION
Referencing (https://github.com/millerjv/PkModeling/issues/43).

I've added a radio-button option in the Advanced Options section of PkModeling to pick an integration method from one of two choices: Recursive and Convolutional. 

Convolutional was PkModeling's previous method. This method did not get perfect performance on the Duke QIBA v6 Tofts Model phantom (see https://sites.duke.edu/dblab/qibacontent/), although it got close. 

Recursive is the new method. It gets perfect performance on the new phantom, and is leagues faster than the other integration method. Performance on the v9 noisy phantom is about equal between the two, so the primary benefits on actual real-life data may come from the speed bonus. My theory for why it is faster is that the Convolutional method is either O(n log n) or O(n^2) at each iteration where n is the length of the time series analyzed, whereas the Recursive method is O(n). I haven't actually worked out the math on this one though, so I could be wrong. Experimentally, the recursive method is ~1000x faster on the 1300 frame v6 phantom, and about 1.5-2x as fast on a 64-timepoint normal MRI.

@kalpathy had once mentioned that PkModeling might have been slower on Windows than it was on Mac/Linux, and I haven't yet been able to test the Convolution method on Max/Linux. At least, however, this new integration method is a very fast solution for Windows users.