### PR TITLE
ENH: Added CI build status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# CI Build Stats
+|                                | Linux and macOS                                                                                                                        | Windows                                                                                                                                                                     |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Build Status for latest master | [![Build Status](https://travis-ci.org/michaelschwier/PkModeling.svg?branch=master)](https://travis-ci.org/michaelschwier/PkModeling)  | [![AppVeyor](https://ci.appveyor.com/api/projects/status/fuq52ak3ry31o5yk/branch/master?svg=true)](https://ci.appveyor.com/project/michaelschwier/pkmodeling/branch/master) |
+
+
+
 # PkModeling
 PkModeling is a [3D Slicer Version 4](http://www.slicer.org) Extension that provides pharmacokinetic modeling for dynamic contrast enhanced MRI (DCE MRI)[1][2]. See documentation at https://www.slicer.org/wiki/Documentation/Nightly/Modules/PkModeling.
 


### PR DESCRIPTION
@fedorov: The status badges point to the CIs which access my fork of PkModeling of course (since the CI platforms access my account). To have the status badges for the original you would need to create AppVeyor and Travis Accounts for "millerjv" and then adapt the link.

However, in any case the status badges in the readme will only be correct for one specific repository/branch and diverge for all forks :/ This could be confusing. Should we maybe add what specific repositiory/branch the badges are shown for (e.g.: "Build Status for michaelschwier/PkModeling/Master")?

Correct/matching CI stats for each repo/branch are automatically integrated by github under "branches", for each account that is linked to a CI provider)