### PR TITLE
COMP: Fix Slicer extension packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,11 +297,11 @@ endif()
 #-----------------------------------------------------------------------------
 # Packaging
 #
+set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${CMAKE_BINARY_DIR};${PROJECT_NAME};RuntimeLibraries;/")
 
 if(DEFINED Slicer_DIR)
   include(${Slicer_EXTENSION_CPACK})
 else()
-  set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${CMAKE_BINARY_DIR};${PROJECT_NAME};RuntimeLibraries;/")
   if(EXISTS "${PkModeling_DIR}/cmake_install.cmake")
     set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${DCMTK_DIR};DCMTK;shlib;/")
   endif()


### PR DESCRIPTION
Setting CPACK_INSTALL_CMAKE_PROJECTS variable became a requirement
following Slicer r25181. That said extensions only started to fail
packaging recently because fix introduced in r25181 was made effective
after Slicer r26488.

See https://discourse.slicer.org/t/extension-build-failures/1274/4

r25181: BUG: Extension packaging: For SuperBuild extension, ensure fixup happens last
r26488: COMP: Ensure 3rd libs and binaries are fixed up for SuperBuild extensions

http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=25181
http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=26488